### PR TITLE
Add a native plugin-API to OBody.

### DIFF
--- a/Source/Scripts/OBodyNGMCMScript.psc
+++ b/Source/Scripts/OBodyNGMCMScript.psc
@@ -103,7 +103,7 @@ event OnOptionSelect(int option)
 		endif
 
 		if (actorInCrosshair)
-			OBodyNative.ResetActorOBodyMorphs(actorInCrosshair)
+			OBodyNative.AssignPresetToActor(actorInCrosshair, "")
 			StorageUtil.UnsetStringValue(none, "obody_" + actorInCrosshair.GetActorBase().GetName() + "_preset")
 			StorageUtil.UnsetStringValue(none, "obody_" + actorInCrosshair.GetFormID() + "_preset")
 		endif

--- a/Source/Scripts/OBodyNGScript.psc
+++ b/Source/Scripts/OBodyNGScript.psc
@@ -108,13 +108,7 @@ Function ShowPresetMenu(Actor act)
 	UIListMenu listMenu = UIExtensions.GetMenu("UIListMenu") as UIListMenu
 	listMenu.ResetMenu()
 
-	string actorPresetKey = "obody_" + act.GetFormID() + "_preset"
-	string currentPreset = StorageUtil.GetStringValue(none, actorPresetKey, missing = "")
-
-	if currentPreset == ""
-		actorPresetKey = "obody_" + act.GetActorBase().GetName() + "_preset"
-		currentPreset = StorageUtil.GetStringValue(none, actorPresetKey, missing = "")
-	endif
+	string currentPreset = OBodyNative.GetPresetAssignedToActorExhaustively(act)
 
 	if currentPreset == ""
 		currentPreset = "Unknown/Unassigned Preset"
@@ -179,7 +173,7 @@ Function ShowPresetMenu(Actor act)
 		OBodyNative.ApplyPresetByName(act, result)
 		Console("Applying: " + result)
 
-		StorageUtil.SetStringValue(none, actorPresetKey, result)
+		StorageUtil.SetStringValue(none, "obody_" + act.GetFormID() + "_preset", result)
 
 		int me = ModEvent.Create("obody_manualchange")
 		ModEvent.PushForm(me, act)

--- a/Source/Scripts/OBodyNGScript.psc
+++ b/Source/Scripts/OBodyNGScript.psc
@@ -64,6 +64,11 @@ EndFunction
 
 
 Event OnActorGenerated(Actor akActor, string presetName)
+	; Dear mod authors,
+	; This method of preset assignment storage has been obsoleted by OBody's native code.
+	; Please use `OBodyNative.GetPresetAssignedToActorExhaustively` and `OBodyNative.AssignPresetToActor`
+	; instead of manipulating this key directly.
+	; Thank you.
 	string actorPresetKey = "obody_" + akActor.GetFormID() + "_preset"
 	StorageUtil.SetStringValue(none, actorPresetKey, presetName)
 EndEvent

--- a/Source/Scripts/OBodyNative.psc
+++ b/Source/Scripts/OBodyNative.psc
@@ -69,3 +69,11 @@ EndFunction
 ; Previous preset assignments stored via StorageUtil are not found by this function,
 ; use `GetPresetAssignedToActorExhaustively` unless you have a reason not to.
 String Function GetPresetAssignedToActor(Actor a_actor) Global Native
+
+; Unlike `ApplyPresetByName` this applies a preset only if a preset with the name
+; is found instead of falling back to a random preset.
+; Additionally, this can be used to remove the preset assignment from an actor
+; by supplying an empty string.
+; `a_doNotApplyMorphs` takes precedence over `a_forceImmediateApplicationOfMorphs`.
+; This returns whether the preset assignment succeeded or not.
+Bool Function AssignPresetToActor(Actor a_actor, String a_presetName, Bool a_forceImmediateApplicationOfMorphs = True, Bool a_doNotApplyMorphs = False) Global Native

--- a/Source/Scripts/OBodyNative.psc
+++ b/Source/Scripts/OBodyNative.psc
@@ -45,3 +45,5 @@ Function SetPerformanceMode(Bool a_enabled) Global Native
 Function SetDistributionKey(String a_distributionKey) Global Native
 
 Function ResetActorOBodyMorphs(Actor a_actor) Global Native
+
+Function ReapplyActorOBodyMorphs(Actor a_actor) Global Native

--- a/Source/Scripts/OBodyNative.psc
+++ b/Source/Scripts/OBodyNative.psc
@@ -47,3 +47,25 @@ Function SetDistributionKey(String a_distributionKey) Global Native
 Function ResetActorOBodyMorphs(Actor a_actor) Global Native
 
 Function ReapplyActorOBodyMorphs(Actor a_actor) Global Native
+
+String Function GetPresetAssignedToActorExhaustively(Actor a_actor) Global
+	String presetName = GetPresetAssignedToActor(a_actor)
+
+	If presetName != ""
+		Return presetName
+	EndIf
+
+	presetName = StorageUtil.GetStringValue(none, "obody_" + a_actor.GetFormID() + "_preset", "")
+
+	If presetName != ""
+		Return presetName
+	EndIf
+
+	Return StorageUtil.GetStringValue(none, "obody_" + a_actor.GetActorBase().GetName() + "_preset", "")
+EndFunction
+
+; OBody began keeping track of the preset assigned to an actor via native code
+; starting after version 4.3.7.
+; Previous preset assignments stored via StorageUtil are not found by this function,
+; use `GetPresetAssignedToActorExhaustively` unless you have a reason not to.
+String Function GetPresetAssignedToActor(Actor a_actor) Global Native

--- a/Source/Scripts/OBodyNative.psc
+++ b/Source/Scripts/OBodyNative.psc
@@ -19,9 +19,10 @@ Function MarkForReprocess(Actor a_actor) Global
 EndFunction
 
 Function RemoveClothesOverlay(Actor a_actor) Global
-	NiOverride.ClearBodyMorphKeys(a_actor, "OClothe")
-	NiOverride.ApplyOverrides(a_actor)
+	RemoveClothesOverlay_(a_actor)
 EndFunction
+
+Function RemoveClothesOverlay_(Actor a_actor) Global Native
 
 Function AddClothesOverlay(Actor a_actor) Global Native
 


### PR DESCRIPTION
This is a complementary PR for a change to the native side of OBody, here: https://github.com/Aietos/OBody-NG/pull/6

---

This PR makes the Papyrus side of OBody use the native mechanism for preset assignment, and exposes some additions to the OBody API.

Preset assignments are still stored via StorageUtil in `OnActorGenerated` for backwards compatibility with mods that expect it to be there.
Other than for that it's no longer used by OBody, so getting rid of it at some point—or even disabling it via an option—could reduce the save-file space usage of OBody.
